### PR TITLE
babel 2.16.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+pbp_autopublish: false
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Babel" %}
-{% set version = "2.11.0" %}
+{% set version = "2.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5ef4b3226b0180dedded4229651c8b0e1a3a6a2837d45a073272f313e4cf97f6
+  sha256: d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
 
 build:
   number: 0
-  skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pybabel = babel.messages.frontend:main
 
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python
-    - pytz >=2015.7
+    - pytz >=2015.7  # [py<39]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "Babel" %}
+{% set name = "babel" %}
 {% set version = "2.16.0" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - pip
     - python
     - setuptools
-    - pytz
     - wheel
   run:
     - python


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6804](https://anaconda.atlassian.net/browse/PKG-6804)
- [Upstream repo](https://github.com/python-babel/babel/tree/v2.16.0)
- release-diff: https://github.com/python-babel/babel/compare/v2.11.0...v2.16.0
- changelog: https://github.com/python-babel/babel/blob/master/CHANGES.rst
- requirements-tagged:
  - https://github.com/python-babel/babel/blob/v2.16.0/pyproject.toml
  - https://github.com/python-babel/babel/blob/v2.16.0/setup.cfg
  - https://github.com/python-babel/babel/blob/v2.16.0/setup.py


### Explanation of changes:

- Skip py<38
- Build for py313

### Notes:

-

[PKG-6804]: https://anaconda.atlassian.net/browse/PKG-6804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ